### PR TITLE
feat: add logical timeout helpers to RetrySettings

### DIFF
--- a/src/RetrySettings.php
+++ b/src/RetrySettings.php
@@ -175,18 +175,8 @@ namespace Google\ApiCore;
  * To configure the use of a logical timeout, where a logical timeout is the
  * duration a method is given to complete one or more RPC attempts, with each
  * attempt using only the time remaining in the logical timeout, use
- * {@see Google\ApiCore\RetrySettings::withLogicalTimeout()}.
- *
- * ```
- * $customRetrySettings = $customRetrySettings->withLogicalTimeout(30000);
- *
- * $result = $client->listGroups($name, [
- *     'retrySettings' => $customRetrySettings
- * ]);
- * ```
- *
- * You can also combine {@see Google\ApiCore\RetrySettings::logicalTimeout()}
- * and {@see Google\ApiCore\RetrySettings::with()}.
+ * {@see Google\ApiCore\RetrySettings::logicalTimeout()} combined with
+ * {@see Google\ApiCore\RetrySettings::with()}.
  *
  * ```
  * $timeoutSettings = RetrySettings::logicalTimeout(30000);
@@ -387,33 +377,6 @@ class RetrySettings
             'noRetriesRpcTimeoutMillis' => $this->getNoRetriesRpcTimeoutMillis(),
         ];
         return new RetrySettings($settings + $existingSettings);
-    }
-
-    /**
-     * Creates a new instance of RetrySettings that updates the timeout settings in the existing
-     * instance with the timeout specified in the $timeout parameter interpreted as a logical timeout.
-     * All other settings (exponential backoff delay, retryable codes, etc.) remain the same.
-     *
-     * @param int $timeout {
-     *     The timeout in milliseconds to be used as a logical call timeout.
-     * }
-     * @return RetrySettings
-     */
-    public function withLogicalTimeout($timeout)
-    {
-        $settings = [
-            'initialRetryDelayMillis' => $this->getInitialRetryDelayMillis(),
-            'retryDelayMultiplier' => $this->getRetryDelayMultiplier(),
-            'maxRetryDelayMillis' => $this->getMaxRetryDelayMillis(),
-            'initialRpcTimeoutMillis' => $timeout,
-            'rpcTimeoutMultiplier' => 1.0,
-            'maxRpcTimeoutMillis' => $timeout,
-            'totalTimeoutMillis' => $timeout,
-            'noRetriesRpcTimeoutMillis' => $timeout,
-            'retryableCodes' => $this->getRetryableCodes(),
-            'retriesEnabled' => $this->retriesEnabled(),
-        ];
-        return new RetrySettings($settings);
     }
 
     /**

--- a/src/RetrySettings.php
+++ b/src/RetrySettings.php
@@ -399,7 +399,7 @@ class RetrySettings
      * }
      * @return RetrySettings
      */
-    public function withLogicalTimeout(int $timeout)
+    public function withLogicalTimeout($timeout)
     {
         $settings = [
             'initialRetryDelayMillis' => $this->getInitialRetryDelayMillis(),
@@ -425,7 +425,7 @@ class RetrySettings
      * }
      * @return array
      */
-    public static function logicalTimeout(int $timeout)
+    public static function logicalTimeout($timeout)
     {
         return [
             'initialRpcTimeoutMillis' => $timeout,

--- a/tests/Tests/Unit/Middleware/RetryMiddlewareTest.php
+++ b/tests/Tests/Unit/Middleware/RetryMiddlewareTest.php
@@ -184,7 +184,7 @@ class RetryMiddlewareTest extends TestCase
                 'retriesEnabled' => true,
                 'retryableCodes' => [ApiStatus::CANCELLED],
             ])
-            ->withLogicalTimeout($timeout);
+            ->with(RetrySettings::logicalTimeout($timeout));
         $callCount = 0;
         $observedTimeouts = [];
         $handler = function(Call $call, $options) use (&$callCount, &$observedTimeouts) {

--- a/tests/Tests/Unit/Middleware/RetryMiddlewareTest.php
+++ b/tests/Tests/Unit/Middleware/RetryMiddlewareTest.php
@@ -174,4 +174,64 @@ class RetryMiddlewareTest extends TestCase
         $middleware($call, $options);
         $this->assertTrue($handlerCalled);
     }
+
+    public function testRetryLogicalTimeout()
+    {
+        $timeout = 2000;
+        $call = $this->getMock(Call::class, [], [], '', false);
+        $retrySettings = RetrySettings::constructDefault()
+            ->with([
+                'retriesEnabled' => true,
+                'retryableCodes' => [ApiStatus::CANCELLED],
+            ])
+            ->withLogicalTimeout($timeout);
+        $callCount = 0;
+        $observedTimeouts = [];
+        $handler = function(Call $call, $options) use (&$callCount, &$observedTimeouts) {
+            $callCount += 1;
+            $observedTimeouts[] = $options['timeoutMillis'];
+            return $promise = new Promise(function () use (&$promise, $callCount) {
+                if ($callCount < 3) {
+                    throw new ApiException('Cancelled!', Code::CANCELLED, ApiStatus::CANCELLED);
+                }
+                $promise->resolve('Ok!');
+            });
+        };
+        $middleware = new RetryMiddleware($handler, $retrySettings);
+        $response = $middleware(
+            $call,
+            []
+        )->wait();
+
+        $this->assertEquals('Ok!', $response);
+        $this->assertEquals(3, $callCount);
+        $this->assertEquals(3, count($observedTimeouts));
+        $this->assertEquals($observedTimeouts[0], $timeout);
+        for ($i = 1; $i < count($observedTimeouts); $i++) {
+            $this->assertTrue($observedTimeouts[$i-1] > $observedTimeouts[$i]);
+        }
+    }
+
+    public function testNoRetryLogicalTimeout()
+    {
+        $timeout = 2000;
+        $call = $this->getMock(Call::class, [], [], '', false);
+        $retrySettings = RetrySettings::constructDefault()
+            ->with(RetrySettings::logicalTimeout($timeout));
+        $observedTimeout = 0;
+        $handler = function(Call $call, $options) use (&$observedTimeout) {
+            $observedTimeout = $options['timeoutMillis'];
+            return $promise = new Promise(function () use (&$promise) {
+                $promise->resolve('Ok!');
+            });
+        };
+        $middleware = new RetryMiddleware($handler, $retrySettings);
+        $response = $middleware(
+            $call,
+            []
+        )->wait();
+
+        $this->assertEquals('Ok!', $response);
+        $this->assertEquals($observedTimeout, $timeout);
+    }
 }

--- a/tests/Tests/Unit/RetrySettingsTest.php
+++ b/tests/Tests/Unit/RetrySettingsTest.php
@@ -143,26 +143,6 @@ class RetrySettingsTest extends TestCase
         $this->compare($withRetrySettings, $expectedValues);
     }
 
-    public function testWithLogicalTimeout()
-    {
-        $timeout = 10000;
-        $retrySettings = RetrySettings::constructDefault();
-        $expectedValues = [
-            'initialRetryDelayMillis' => $retrySettings->getInitialRetryDelayMillis(),
-            'retryDelayMultiplier' => $retrySettings->getRetryDelayMultiplier(),
-            'maxRetryDelayMillis' => $retrySettings->getMaxRetryDelayMillis(),
-            'retryableCodes' => $retrySettings->getRetryableCodes(),
-            'retriesEnabled' => $retrySettings->retriesEnabled(),
-            'rpcTimeoutMultiplier' => 1.0,
-            'initialRpcTimeoutMillis' => $timeout,
-            'maxRpcTimeoutMillis' => $timeout,
-            'totalTimeoutMillis' => $timeout,
-            'noRetriesRpcTimeoutMillis' => $timeout
-        ];
-        $updatedSettings = $retrySettings->withLogicalTimeout($timeout);
-        $this->compare($updatedSettings, $expectedValues);
-    }
-
     public function testLogicalTimeout()
     {
         $timeout = 10000;

--- a/tests/Tests/Unit/RetrySettingsTest.php
+++ b/tests/Tests/Unit/RetrySettingsTest.php
@@ -143,6 +143,43 @@ class RetrySettingsTest extends TestCase
         $this->compare($withRetrySettings, $expectedValues);
     }
 
+    public function testWithLogicalTimeout()
+    {
+        $timeout = 10000;
+        $retrySettings = RetrySettings::constructDefault();
+        $expectedValues = [
+            'initialRetryDelayMillis' => $retrySettings->getInitialRetryDelayMillis(),
+            'retryDelayMultiplier' => $retrySettings->getRetryDelayMultiplier(),
+            'maxRetryDelayMillis' => $retrySettings->getMaxRetryDelayMillis(),
+            'retryableCodes' => $retrySettings->getRetryableCodes(),
+            'retriesEnabled' => $retrySettings->retriesEnabled(),
+            'rpcTimeoutMultiplier' => 1.0,
+            'initialRpcTimeoutMillis' => $timeout,
+            'maxRpcTimeoutMillis' => $timeout,
+            'totalTimeoutMillis' => $timeout,
+            'noRetriesRpcTimeoutMillis' => $timeout
+        ];
+        $updatedSettings = $retrySettings->withLogicalTimeout($timeout);
+        $this->compare($updatedSettings, $expectedValues);
+    }
+
+    public function testLogicalTimeout()
+    {
+        $timeout = 10000;
+        $expectedValues = [
+            'initialRpcTimeoutMillis' => $timeout,
+            'maxRpcTimeoutMillis' => $timeout,
+            'totalTimeoutMillis' => $timeout,
+            'noRetriesRpcTimeoutMillis' => $timeout,
+            'rpcTimeoutMultiplier' => 1.0
+        ];
+        $timeoutSettings = RetrySettings::logicalTimeout($timeout);
+        $this->assertSame(
+            $expectedValues,
+            $timeoutSettings
+        );
+    }
+
     private function compare(RetrySettings $retrySettings, $expectedValues)
     {
         $this->assertSame(


### PR DESCRIPTION
This PR adds a helper to the `RetrySettings` for configuring a logical call timeout. This helper, `logicalTimeout`, takes a single integer and applies it to each of the four existing timeout settings and sets the timeout multiplier to 1, returning an associative array for use with `with()` or via the `retrySettings` call option. The result is that each RPC attempt will take no longer than the time remaining in the overall deadline calculated at the start of the first call using the given timeout. The time remaining in this overall deadline is the timeout for each RPC attempt.

This helper is meant to simplify how users can think about the timeout settings, and reduce the need for `DEADLINE_EXCEEDED` to be retryable, which is an anti-pattern, but necessary for the "timeout backoff" strategy available via the existing retry/timeout logic.